### PR TITLE
Add support for appup.src dependency overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ endif
 
 .PHONY: all compile clean dialyzer test
 
-travis: test
+travis: update test
+
 all: deps compile
 
 # =============================================================================
@@ -44,6 +45,9 @@ compile: $(REBAR3)
 
 clean: $(REBAR3)
 	- $(REBAR3) clean
+
+update:
+	$(REBAR3) update
 
 test: compile
 	rm -rf _build/test

--- a/src/rebar3_appup_utils.erl
+++ b/src/rebar3_appup_utils.erl
@@ -124,7 +124,8 @@ tmp_filename() ->
 %% @spec find_app_info(_,_) -> any().
 find_app_info(Name, State) ->
     Apps = rebar_state:project_apps(State),
-    find_app_info1(Name, Apps).
+    Deps = rebar_state:all_deps(State),
+    find_app_info1(Name, Apps ++ Deps).
 
 %% @spec find_app_info1(_,maybe_improper_list()) -> any().
 find_app_info1(_Name, []) -> undefined;

--- a/test/rebar3_appup_plugin_SUITE.erl
+++ b/test/rebar3_appup_plugin_SUITE.erl
@@ -49,7 +49,8 @@ groups() ->
          appup_src_template_vars,
          appup_src_state_var_scripting,
          add_supervisor_worker, remove_supervisor_worker,
-         multiple_behaviours]
+         multiple_behaviours,
+         custom_application_appup]
      }].
 
 init_per_suite(Config) ->
@@ -697,6 +698,26 @@ multiple_behaviours(Config) when is_list(Config) ->
                                 [{update,relapp_app_sup,supervisor}],
                                 [{update,relapp_app_sup,supervisor}]
                            },
+                           [{delete_appup_src, true}],
+                           Config),
+    ok.
+
+custom_application_appup(doc) -> ["Use a custom appup maintained in the application for defining upgrade "
+                                  " instructions for a dependency"];
+custom_application_appup(suite) -> [];
+custom_application_appup(Config) when is_list(Config) ->
+    AfterUpgradeFun = fun(DeployDir, State) ->
+                            {ok, "0.5.2"} = get_app_version("statsderl", DeployDir),
+                            State
+                      end,
+    AfterDowngradeFun = fun(DeployDir, State) ->
+                            {ok, "0.3.5"} = get_app_version("statsderl", DeployDir),
+                            State
+                        end,
+    ok = upgrade_downgrade("relapp1", "1.0.24", "1.0.25",
+                           [{after_upgrade, AfterUpgradeFun},
+                            {after_downgrade, AfterDowngradeFun}],
+                           {[], []},
                            [{delete_appup_src, true}],
                            Config),
     ok.


### PR DESCRIPTION
Allow an application to define the .appup.src
file of a dependency, this is useful when these
do no provide an .appup file of their own.

Addresses #13 