### PR TITLE
filter beam file what only abst chunk different

### DIFF
--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -297,8 +297,10 @@ generate_appup_files(TargetDir,
     NewRelEbinDir = filename:join([NewVerPath, "lib",
                                 atom_to_list(App) ++ "-" ++ NewVer, "ebin"]),
 
-    {AddedFiles, DeletedFiles, ChangedFiles} = beam_lib:cmp_dirs(NewRelEbinDir,
+    {AddedFiles, DeletedFiles, ChangedFiles0} = beam_lib:cmp_dirs(NewRelEbinDir,
                                                                  OldRelEbinDir),
+    ChangedFiles = filter_abst_chunks_different(ChangedFiles0),
+
     rebar_api:debug("beam files:", []),
     rebar_api:debug("   added: ~p", [AddedFiles]),
     rebar_api:debug("   deleted: ~p", [DeletedFiles]),
@@ -662,3 +664,19 @@ generate_tuple(7) -> {undefined, undefined, undefined, undefined,
                       undefined, undefined, undefined};
 generate_tuple(8) -> {undefined, undefined, undefined, undefined,
                       undefined, undefined, undefined, undefined}.
+
+filter_abst_chunks_different(ChangedFiles) ->
+    case beam_lib:get_crypto_key({debug_info, des3_cbc, none, none}) of
+        error -> %% skip
+            ChangedFiles;
+        _ ->
+            lists:foldl(
+                fun({NewFile, OldFile} = ChangedFile, List) ->
+                    case beam_lib:cmp(NewFile, OldFile) of
+                        {error, beam_lib, {chunks_different, "Abst"}} -> %% skip
+                            List;
+                        _ ->
+                            [ChangedFile | List]
+                    end
+                end, [], ChangedFiles)
+    end.


### PR DESCRIPTION
When I add `encrypt_debug_info` to `erl_opts`,I found some files that I did not make changes in the appup file.Then I found this from otp's [source](https://github.com/erlang/otp/blob/a98379d0519c28f9bc9b673ed2c09fb1ad52456e/lib/compiler/src/compile.erl#L1437), It use `crypto:strong_rand_bytes/1` when encrypt `abstract_code`, So the `Abst` chunks  is not always the same.