### PR TITLE
Merge .appup.pre.src & .appup.post.src files into the generated appup

### DIFF
--- a/priv/templates/appup.tpl
+++ b/priv/templates/appup.tpl
@@ -1,7 +1,7 @@
 %% appup generated for {{app}} by rebar3_appup_plugin ({{{now}}})
 { "{{{new_vsn}}}",
     [{ "{{{old_vsn}}}",
-        {{upgrade_instructions}} }],
+        {{{upgrade_instructions}}} }],
     [{ "{{{old_vsn}}}",
-        {{downgrade_instructions}} }]
+        {{{downgrade_instructions}}} }]
 }.

--- a/test/rebar3_appup_plugin_SUITE.erl
+++ b/test/rebar3_appup_plugin_SUITE.erl
@@ -18,7 +18,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(rebar3_appup_plugin_SUITE).
--compile([export_all]).
+-compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -31,27 +31,30 @@ all() ->
 
 groups() ->
     [{generate, [],
-        [empty_appup, supervisor_appup,
-         new_gen_server_appup,
-         new_gen_server_state_appup,
-         add_fields_gen_server_state_appup,
-         add_field_middle_gen_server_state_appup,
-         replace_field_middle_gen_server_state_appup,
-         new_dependency_appup,
-         remove_dependency_appup,
-         restore_dependency_appup,
-         new_auto_gen_server_appup,
-         add_fields_auto_gen_server_state_appup,
-         new_simple_module, simple_module_use,
-         brutal_purge_test, soft_purge_test,
-         appup_src_scripting,
-         appup_src_extra_argument,
-         appup_src_template_vars,
-         appup_src_state_var_scripting,
-         add_supervisor_worker, remove_supervisor_worker,
-         multiple_behaviours,
-         custom_application_appup,
-         capital_named_modules]
+        [
+          empty_appup, supervisor_appup,
+          new_gen_server_appup,
+          new_gen_server_state_appup,
+          add_fields_gen_server_state_appup,
+          add_field_middle_gen_server_state_appup,
+          replace_field_middle_gen_server_state_appup,
+          new_dependency_appup,
+          remove_dependency_appup,
+          restore_dependency_appup,
+          new_auto_gen_server_appup,
+          add_fields_auto_gen_server_state_appup,
+          new_simple_module, simple_module_use,
+          brutal_purge_test, soft_purge_test,
+          appup_src_scripting,
+          appup_src_extra_argument,
+          appup_src_template_vars,
+          appup_src_state_var_scripting,
+          add_supervisor_worker, remove_supervisor_worker,
+          multiple_behaviours,
+          custom_application_appup,
+          capital_named_modules,
+          post_pre_generate
+        ]
      }].
 
 init_per_suite(Config) ->
@@ -733,6 +736,24 @@ capital_named_modules(Config) when is_list(Config) ->
                            [{delete_appup_src, true}],
                            Config),
     ok.
+
+post_pre_generate(doc) -> ["generate post pre"];
+post_pre_generate(suite) -> [];
+post_pre_generate(Config) ->
+    ok = upgrade_downgrade(
+             "relapp1", "1.0.33", "1.0.34",
+             [],
+             {[{apply,{io,format,["Upgrading started from 1.* to 1.0.34"]}},
+               {apply,{io,format, ["Upgrading started from 1.0.33 to 1.0.34"]}},
+               {apply,{io,format, ["Upgrading finished from 1.* to 1.0.34"]}},
+               {apply,{io,format, ["Upgrading finished from 1.0.33 to 1.0.34"]}}],
+              [{apply,{io,format, ["Downgrading started from 1.0.34 to .*"]}},
+               {apply,{io,format, ["Downgrading started from 1.0.34 to 1.0.33"]}},
+               {apply,{io,format, ["Downgrading finished from 1.0.34 to .*"]}},
+               {apply,{io,format, ["Downgrading finished from 1.0.34 to 1.0.33"]}}]},
+             [{delete_appup_src, true}],
+             Config),
+  ok.
 
 %% -------------------------------------------------------------
 %% Private methods

--- a/test/rebar3_appup_plugin_eunit_tests.erl
+++ b/test/rebar3_appup_plugin_eunit_tests.erl
@@ -1,0 +1,128 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Luis Rascão.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(rebar3_appup_plugin_eunit_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+matching_version1_test() ->
+  test_matching(".*", "1.0.2", true).
+
+matching_version2_test() ->
+  test_matching("1.*", "1.0.2", true).
+
+matching_version3_test() ->
+  test_matching("*.*.2", "1.0.2", true).
+
+matching_version4_test() ->
+  test_matching("*.*.3", "1.0.2", false).
+
+%% Check exact versions
+pattern1_test() ->
+  test_matching_patterns(
+    {"1.0.34",
+     [{"1.0.33", [{apply, {io, format, ["Upgrading started from 1.0.33 to 1.0.34"]}}]}],
+     [{"1.0.33", [{apply, {io, format, ["Downgrading started from 1.0.34 to 1.0.33"]}}]}]},
+    {"1.0.34",
+     [{"1.0.33", [{apply, {io, format, ["Upgrading finished from 1.0.33 to 1.0.34"]}}]}],
+     [{"1.0.33", [{apply, {io, format, ["Downgrading finished from 1.0.34 to 1.0.33"]}}]}]},
+    "1.0.33", "1.0.34",
+    [{apply,{io,format,["Upgrading is in progress..."]}}],
+    [{apply,{io,format,["Downgrading is in progress..."]}}],
+    {[{apply,{io,format,["Upgrading started from 1.0.33 to 1.0.34"]}},
+      {apply,{io,format,["Upgrading is in progress..."]}},
+      {apply,{io,format,["Upgrading finished from 1.0.33 to 1.0.34"]}}],
+     [{apply,{io,format,["Downgrading started from 1.0.34 to 1.0.33"]}},
+      {apply,{io,format,["Downgrading is in progress..."]}},
+      {apply,{io,format,["Downgrading finished from 1.0.34 to 1.0.33"]}}]}
+   ).
+
+%% New ver is a pattern
+pattern2_test() ->
+  test_matching_patterns(
+    {".*",
+     [{"1.0.33", [{apply, {io, format, ["Upgrading started from 1.0.33 to 1.*"]}}]}],
+     [{"1.0.33", [{apply, {io, format, ["Downgrading started from 1.* to 1.0.33"]}}]}]},
+    {"1.*",
+     [{"1.0.33", [{apply, {io, format, ["Upgrading finished from 1.0.33 to 1.*"]}}]}],
+     [{"1.0.33", [{apply, {io, format, ["Downgrading finished from 1.* to 1.0.33"]}}]}]},
+    "1.0.33", "1.0.34",
+    [{apply,{io,format,["Upgrading is in progress..."]}}],
+    [{apply,{io,format,["Downgrading is in progress..."]}}],
+    {[{apply,{io,format,["Upgrading started from 1.0.33 to 1.*"]}},
+      {apply,{io,format,["Upgrading is in progress..."]}},
+      {apply,{io,format,["Upgrading finished from 1.0.33 to 1.*"]}}],
+     [{apply,{io,format,["Downgrading started from 1.* to 1.0.33"]}},
+      {apply,{io,format,["Downgrading is in progress..."]}},
+      {apply,{io,format,["Downgrading finished from 1.* to 1.0.33"]}}]}
+   ).
+
+%% Both new and old versions are patterns.
+%% Check upgrade between 1.* <--> 2.*
+pattern3_test() ->
+  test_matching_patterns(
+    {"2.*",
+     [{"1.*", [{apply, {io, format, ["Upgrading started from 1.* to 2.*"]}}]}],
+     [{"1.*", [{apply, {io, format, ["Downgrading started from 2.* to 1.*"]}}]}]},
+    {"2.*",
+     [{"1.*", [{apply, {io, format, ["Upgrading finished from 1.* to 2.*"]}}]}],
+     [{"1.*", [{apply, {io, format, ["Downgrading finished from 2.* to 1.*"]}}]}]},
+    "1.0.33", "2.0.1",
+    [{apply,{io,format,["Upgrading is in progress..."]}}],
+    [{apply,{io,format,["Downgrading is in progress..."]}}],
+    {[{apply,{io,format,["Upgrading started from 1.* to 2.*"]}},
+      {apply,{io,format,["Upgrading is in progress..."]}},
+      {apply,{io,format,["Upgrading finished from 1.* to 2.*"]}}],
+     [{apply,{io,format,["Downgrading started from 2.* to 1.*"]}},
+      {apply,{io,format,["Downgrading is in progress..."]}},
+      {apply,{io,format,["Downgrading finished from 2.* to 1.*"]}}]}
+   ).
+
+%% Post conditions are not matching the new version.
+%% They should not be present in the generated appup file
+pattern4_test() ->
+  test_matching_patterns(
+    {"2.*",
+     [{"1.*", [{apply, {io, format, ["Upgrading started from 1.* to 2.*"]}}]}],
+     [{"1.*", [{apply, {io, format, ["Downgrading started from 2.* to 1.*"]}}]}]},
+    {"3.*",    %% intentionally 3.*.... This part won't be in the generated appup
+     [{"1.*", [{apply, {io, format, ["Upgrading finished from 1.* to 2.*"]}}]}],
+     [{"1.*", [{apply, {io, format, ["Downgrading finished from 2.* to 1.*"]}}]}]},
+    "1.0.33", "2.0.1",
+    [{apply,{io,format,["Upgrading is in progress..."]}}],
+    [{apply,{io,format,["Downgrading is in progress..."]}}],
+    {[{apply,{io,format,["Upgrading started from 1.* to 2.*"]}},
+      {apply,{io,format,["Upgrading is in progress..."]}}
+      %% Post instructions are missing
+     ],
+     [{apply,{io,format,["Downgrading started from 2.* to 1.*"]}},
+      {apply,{io,format,["Downgrading is in progress..."]}}
+      %% Post instructions are missing
+     ]}
+   ).
+
+test_matching_patterns(PreContents, PostContents, OldVer, NewVer,
+                       UpgradeInstructions, DowngradeInstructions, Expected) ->
+    Actual = rebar3_appup_generate:merge_instructions(
+               PreContents, PostContents, OldVer, NewVer, UpgradeInstructions, DowngradeInstructions),
+    ?assertEqual(Expected, Actual).
+
+test_matching(Pattern, Version, Expected) ->
+  Actual = rebar3_appup_generate:matching_versions(Pattern, Version),
+  ?assertEqual(Expected, Actual).


### PR DESCRIPTION
Add pre and post instructions to the instuctions created by appup generate.
These instructions must be stored in the .appup.pre.src and .appup.post.src
files in the src folders of the given application.

If one of these files are missing or the version patterns specified in
these files don't match the current old and new versions stored in the
.appup file the corresponding part will be empty. If none of these files
are present the generated appup file will be exactly the same as without
using this feature.