### PR TITLE
Deprecate OTP R16B

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ otp_release:
   - 19.3
   - 18.3
   - 17.5
-  - R16B03-1
 before_script:
   - wget https://s3.amazonaws.com/rebar3-nightly/rebar3
   - chmod u+x rebar3


### PR DESCRIPTION
Following rebar3's decision due to release of OTP21. (https://github.com/erlang/rebar3/pull/1779)