### PR TITLE
(fix) Support relx release configs that contain opts

### DIFF
--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -734,8 +734,12 @@ get_current_rel_path(State, Name) ->
       Res :: string().
 get_release_name(State) ->
     RelxConfig = rebar_state:get(State, relx, []),
-    {release, {Name0, _Ver}, _} = lists:keyfind(release, 1, RelxConfig),
-    atom_to_list(Name0).
+    case lists:keyfind(release, 1, RelxConfig) of
+        {release, {Name0, _Ver}, _} ->
+            atom_to_list(Name0);
+        {release, {Name0, _Ver}, _, _} ->
+            atom_to_list(Name0)
+    end.
 
 %%------------------------------------------------------------------------------
 %%

--- a/src/rebar3_appup_tar.erl
+++ b/src/rebar3_appup_tar.erl
@@ -56,8 +56,12 @@ init(State) ->
 %% @spec do(rebar_state:t()) -> {'ok',rebar_state:t()} | {'error',string()}.
 do(State) ->
     RelxConfig = rebar_state:get(State, relx, []),
-    {release, {Name0, _Ver}, _} = lists:keyfind(release, 1, RelxConfig),
-    Name = atom_to_list(Name0),
+    Name = case lists:keyfind(release, 1, RelxConfig) of
+               {release, {Name0, _Ver}, _} ->
+                   atom_to_list(Name0);
+               {release, {Name0, _Ver}, _, _} ->
+                   atom_to_list(Name0)
+           end,
     rebar_api:debug("release name: ~p", [Name]),
 
     RelDir = filename:join([rebar_dir:base_dir(State),


### PR DESCRIPTION
This PR contains a fix for relx release configs with opts that would otherwise crash the plugin with:
```
===> Uncaught error: {badmatch,
                             {release,
                              {myapp,"2.0.1"},
                              [{myapp,"2.0.1"},parse_trans,sasl],
                              [{overlay,
                                [{template,"rel/files/vm.args",
                                  "releases/{{rel_vsn}}/vm.args"},
                                 {template,"rel/files/myapp.config",
                                  "releases/{{rel_vsn}}/sys.config"}]},
                               {extended_start_script,true}]}}
```

Example of an unsupported config:
```
{relx, [{release, {myapp, "2.0.1"},
         [{myapp, "2.0.1"}, parse_trans, sasl],
         [{overlay, [{template, "rel/files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
                     {template, "rel/files/myapp.config", "releases/\{\{rel_vsn\}\}/sys.config"}]},
          {extended_start_script, true}]},
        {release, {myapp_node, "2.0.1"},
         [{myapp, "2.0.1"}, parse_trans, sasl],
         [{overlay, [{template, "rel/files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
                     {template, "rel/files/myapp_node.config", "releases/\{\{rel_vsn\}\}/sys.config"},
                     {copy, "rel/files/migrate-myapp-node", "bin/migrate-myapp-node"},
                     {copy, "rel/files/rollback-myapp-node", "bin/rollback-myapp-node"}]},
          {extended_start_script, true}]},
        {release, {myapp_core, "2.0.1"},
         [{myapp, "2.0.1"}, parse_trans, sasl],
         [{overlay, [{template, "rel/files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
                     {template, "rel/files/myapp_core.config", "releases/\{\{rel_vsn\}\}/sys.config"},
                     {copy, "rel/files/migrate-myapp-core", "bin/migrate-myapp-core"},
                     {copy, "rel/files/rollback-myapp-core", "bin/rollback-myapp-core"}]},
          {extended_start_script, true}]}
       ]}.
```