### PR TITLE
(fix) Add -n parameter to accept release name

### DIFF
--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -59,6 +59,7 @@ init(State) ->
             {bare, true},                 % The task can be run by the user, always true
             {deps, ?DEPS},                % The list of dependencies
             {opts, [                      % list of options understood by the plugin
+                {relname, $n, "relname", string, "Release name"},
                 {previous, $p, "previous", string, "location of the previous release"},
                 {previous_version, $p, "previous_version", string, "version of the previous release"},
                 {current, $c, "current", string, "location of the current release"},
@@ -87,7 +88,7 @@ do(State) ->
     PluginInfo = rebar3_appup_utils:appup_plugin_appinfo(Apps),
     PluginDir = rebar_app_info:dir(PluginInfo),
 
-    Name = get_release_name(State),
+    Name = rebar3_appup_utils:get_release_name(State),
     rebar_api:debug("release name: ~p", [Name]),
 
     %% check for overload of the current release
@@ -729,18 +730,6 @@ get_current_rel_path(State, Name) ->
                            ?DEFAULT_RELEASE_DIR,
                            Name]);
         Path -> Path
-    end.
-
--spec get_release_name(State) -> Res when
-      State :: rebar_state:t(),
-      Res :: string().
-get_release_name(State) ->
-    RelxConfig = rebar_state:get(State, relx, []),
-    case lists:keyfind(release, 1, RelxConfig) of
-        {release, {Name0, _Ver}, _} ->
-            atom_to_list(Name0);
-        {release, {Name0, _Ver}, _, _} ->
-            atom_to_list(Name0)
     end.
 
 %%------------------------------------------------------------------------------

--- a/src/rebar3_appup_tar.erl
+++ b/src/rebar3_appup_tar.erl
@@ -55,13 +55,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 %% @spec do(rebar_state:t()) -> {'ok',rebar_state:t()} | {'error',string()}.
 do(State) ->
-    RelxConfig = rebar_state:get(State, relx, []),
-    Name = case lists:keyfind(release, 1, RelxConfig) of
-               {release, {Name0, _Ver}, _} ->
-                   atom_to_list(Name0);
-               {release, {Name0, _Ver}, _, _} ->
-                   atom_to_list(Name0)
-           end,
+    Name = rebar3_appup_utils:get_release_name(State),
     rebar_api:debug("release name: ~p", [Name]),
 
     RelDir = filename:join([rebar_dir:base_dir(State),

--- a/src/rebar3_appup_utils.erl
+++ b/src/rebar3_appup_utils.erl
@@ -19,7 +19,8 @@
 %% -------------------------------------------------------------------
 -module(rebar3_appup_utils).
 
--export([prop_check/3,
+-export([get_release_name/1,
+         prop_check/3,
          make_proplist/2,
          find_files/3,
          find_files_by_ext/2, find_files_by_ext/3,
@@ -34,6 +35,14 @@
          tmp_filename/0,
          find_app_by_name/2,
          vsn/1]).
+
+-spec get_release_name(State) -> Res when
+    State :: rebar_state:t(),
+    Res :: string().
+get_release_name(State) ->
+    RelxConfig = rebar_state:get(State, relx, []),
+    {release, {Name0, _Ver}, _} = lists:keyfind(release, 1, RelxConfig),
+    atom_to_list(Name0).
 
 %% Helper function for checking values and aborting when needed
 %% @spec prop_check(boolean(),_,_) -> any().


### PR DESCRIPTION
Original behavior was to use the default release name configured in `relx`. So, for example, I have this as my relx config:
```
{relx, [{release, {myapp, "2.0.0"},
         [{myapp, "2.0.0"},parse_trans, sasl],
         [{overlay, [{template, "rel/files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
                     {template, "rel/files/myapp.config", "releases/\{\{rel_vsn\}\}/sys.config"},
                     {copy, "rel/files/migrate-myapp-node", "bin/migrate-myapp-node"},
                     {copy, "rel/files/rollback-myapp-node", "bin/rollback-myapp-node"},
                     {copy, "rel/files/migrate-myapp-core", "bin/migrate-myapp-core"},
                     {copy, "rel/files/rollback-myapp-core", "bin/rollback-myapp-core"}]},
          {extended_start_script, true}]},
        {release, {myapp_node, "2.0.0"},
         [{myapp, "2.0.0"},parse_trans, sasl],
         [{overlay, [{template, "rel/files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
                     {template, "rel/files/myapp_node.config", "releases/\{\{rel_vsn\}\}/sys.config"},
                     {copy, "rel/files/migrate-myapp-node", "bin/migrate-myapp-node"},
                     {copy, "rel/files/rollback-myapp-node", "bin/rollback-myapp-node"}]},
          {extended_start_script, true}]},
        {release, {myapp_core, "2.0.0"},
         [{myapp, "2.0.0"},parse_trans, sasl],
         [{overlay, [{template, "rel/files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
                     {template, "rel/files/myapp_core.config", "releases/\{\{rel_vsn\}\}/sys.config"},
                     {copy, "rel/files/migrate-myapp-core", "bin/migrate-myapp-core"},
                     {copy, "rel/files/rollback-myapp-core", "bin/rollback-myapp-core"}]},
          {extended_start_script, true}]}
       ]}.
```

I'm specifying release names: `myapp`, `myapp_node`, and `myapp_core`. The plugin does not support `-n ${RELEASE_NAME}` for `rebar3 appup generate`, so `myapp` would be used everytime. 

This extends the plugin to accept `-n ${RELEASE_NAME}`, and now appups can be generated for whatever the specified release name is. 