### PR TITLE
Use checkouts_out_dir/1 instead of checkouts_dir/1

### DIFF
--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -392,7 +392,7 @@ write_appup(App, OldVer, NewVer, TargetDir,
     CurrentBaseDir = rebar_dir:base_dir(State),
     %% check for the app either in deps or lib
     rebar_api:info("current base dir: ~p", [CurrentBaseDir]),
-    CheckoutsEbinDir = filename:join([rebar_dir:checkouts_dir(State),
+    CheckoutsEbinDir = filename:join([rebar_dir:checkouts_out_dir(State),
                                       atom_to_list(App), "ebin"]),
     DepsEbinDir = filename:join([CurrentBaseDir, "deps",
                                 atom_to_list(App), "ebin"]),


### PR DESCRIPTION
Hi!

Since (at least)  rebar3 version 3.14, the `_checkouts` directory is not where the ebin files are placed, so the appups would fail to generate.

This fixes that and uses the `checkouts_out_dir/1` call instead, which is where newer versions of rebar3 drops the files.

I'm not sure if earlier versions of rebar3 actually did compile checkouts in place in the `_checkouts` dir, but this is the issue I've been trying to figure out recently.

Thanks!