### PR TITLE
fix a crash when evaluating a module with no abstract code

### DIFF
--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -1023,17 +1023,20 @@ cmp_files(File1, File2) ->
 
 -spec read_file(File) -> Res when
       File :: file:filename(),
-      Res :: beam_lib:abst_code().
+      Res :: no_abstract_code | beam_lib:forms().
 read_file(File) ->
-  {ok,{_,[{abstract_code,{_,AC}}]}} = beam_lib:chunks(File,[abstract_code]),
-  filter_ac(AC).
+  {ok,{_,[{abstract_code,AC}]}} = beam_lib:chunks(File,[abstract_code]),
+  case AC of
+    no_abstract_code -> no_abstract_code;
+    {_, Forms} -> filter_ac_forms(Forms)
+  end.
 
--spec filter_ac(AC) -> Res when
-      AC :: beam_lib:abst_code(),
-      Res :: beam_lib:abst_code().
-filter_ac(AC) ->
+-spec filter_ac_forms(Forms) -> Res when
+      Forms :: beam_lib:forms(),
+      Res :: beam_lib:forms().
+filter_ac_forms(Forms) ->
   lists:filter(fun({attribute, _, file, _}) ->
                        false;
                   (_) ->
                        true
-               end, AC).
+               end, Forms).


### PR DESCRIPTION
lrascao/rebar3_appup_plugin#73

I don't actually know how to test this change. rebar3 eunit and rebar3 dialyzer worked both before and after. I don't know exactly how this code is called by rebar3 when operating as a plugin but following the documentation for beam_lib is should handle the types used by beam_lib correctly where it previously did not and crashed as a result. The crash seems to be the kind of thing that should have been caught by dialyzer. I don't know why it didn't.