### PR TITLE
Revert "Filter changes in the beams related to different compile opti…

### DIFF
--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -312,7 +312,9 @@ generate_appup_files(TargetDir,
                                 atom_to_list(App) ++ "-" ++ OldVer, "ebin"]),
     NewRelEbinDir = filename:join([NewVerPath, "lib",
                                 atom_to_list(App) ++ "-" ++ NewVer, "ebin"]),
-    {AddedFiles, DeletedFiles, ChangedFiles} = cmp_dirs(NewRelEbinDir, OldRelEbinDir),
+
+    {AddedFiles, DeletedFiles, ChangedFiles} = beam_lib:cmp_dirs(NewRelEbinDir,
+                                                                 OldRelEbinDir),
     rebar_api:debug("beam files:", []),
     rebar_api:debug("   added: ~p", [AddedFiles]),
     rebar_api:debug("   deleted: ~p", [DeletedFiles]),
@@ -950,93 +952,3 @@ find_file_by_ext(Dir, Ext) ->
         [Path] ->
             Path
     end.
-
--spec cmp_dirs(Dir1, Dir2) -> Res when
-      Dir1 :: file:filename(),
-      Dir2 :: file:filename(),
-      Res :: {list(file:filename()), list(file:filename()),
-              list({file:filename(), file:filename()})}.
-cmp_dirs(Dir1, Dir2) ->
-    catch compare_dirs(Dir1, Dir2).
-
--spec compare_dirs(Dir1, Dir2) -> Res when
-      Dir1 :: file:filename(),
-      Dir2 :: file:filename(),
-      Res :: {list(file:filename()), list(file:filename()),
-              list({file:filename(), file:filename()})}.
-compare_dirs(Dir1, Dir2) ->
-    R1 = sofs:relation(beam_files(Dir1)),
-    R2 = sofs:relation(beam_files(Dir2)),
-    F1 = sofs:domain(R1),
-    F2 = sofs:domain(R2),
-    {O1, Both, O2} = sofs:symmetric_partition(F1, F2),
-    OnlyL1 = sofs:image(R1, O1),
-    OnlyL2 = sofs:image(R2, O2),
-    B1 = sofs:to_external(sofs:restriction(R1, Both)),
-    B2 = sofs:to_external(sofs:restriction(R2, Both)),
-    Diff = compare_files(B1, B2, []),
-    {sofs:to_external(OnlyL1), sofs:to_external(OnlyL2), Diff}.
-
--spec beam_files(Dir) -> Res when
-      Dir :: file:filename(),
-      Res :: list({file:filename(), file:filename()}).
-beam_files(Dir) ->
-    ok = assert_directory(Dir),
-    L = filelib:wildcard(filename:join(Dir, "*.beam")),
-    [{filename:basename(Path), Path} || Path <- L].
-
--spec assert_directory(Dir) -> Res when
-      Dir :: file:filename(),
-      Res :: ok.
-assert_directory(Dir) ->
-    case filelib:is_dir(Dir) of
-        true ->
-            ok;
-        false ->
-            error({not_a_directory, Dir})
-    end.
-
--spec compare_files(Files1, Files2, Acc) -> Res when
-      Files1 :: list({file:filename(), file:filename()}),
-      Files2 :: list({file:filename(), file:filename()}),
-      Acc :: list({file:filename(), file:filename()}),
-      Res :: list({file:filename(), file:filename()}).
-compare_files([], [], Acc) ->
-    lists:reverse(Acc);
-compare_files([{_, File1} | T1], [{_, File2} | T2], Acc) ->
-    Acc1 = case cmp_files(File1, File2) of
-               true ->
-                   Acc;
-               false ->
-                   [{File1, File2} | Acc]
-           end,
-    compare_files(T1, T2, Acc1).
-
--spec cmp_files(File1, File2) -> Res when
-      File1 :: file:filename(),
-      File2 :: file:filename(),
-      Res :: boolean().
-cmp_files(File1, File2) ->
-  L1 = read_file(File1),
-  L2 = read_file(File2),
-  L1 =:= L2.
-
--spec read_file(File) -> Res when
-      File :: file:filename(),
-      Res :: no_abstract_code | beam_lib:forms().
-read_file(File) ->
-  {ok,{_,[{abstract_code,AC}]}} = beam_lib:chunks(File,[abstract_code]),
-  case AC of
-    no_abstract_code -> no_abstract_code;
-    {_, Forms} -> filter_ac_forms(Forms)
-  end.
-
--spec filter_ac_forms(Forms) -> Res when
-      Forms :: beam_lib:forms(),
-      Res :: beam_lib:forms().
-filter_ac_forms(Forms) ->
-  lists:filter(fun({attribute, _, file, _}) ->
-                       false;
-                  (_) ->
-                       true
-               end, Forms).


### PR DESCRIPTION
…ons"

This reverts commit 0a901679181c805c649f3981ce2f818c3b588ab0.

The custom implementation of `cmp_dirs/2` that replaces `beam_lib:cmp_dirs/2` is both broken, causing https://github.com/lrascao/rebar3_appup_plugin/issues/76, and was introduced to achieve an undesirable goal. When changing compile options results in all beam files changing, the rebar3_appup_plugin should generate an appup script updating all beam files. Filtering out beam files that have changed only with respect to compile options is wrong. The current implementation filters out modules with actual logic changes and not just compile options. It is not clear if it's possible to filter out modules with only compile option changes and still identify modules with logic changes, but it doesn't seem worth it to try since this is not a reasonable goal to begin with.