### PR TITLE
OTP 29 compatibility (standalone catch deprecated)

### DIFF
--- a/src/rebar3_appup_compile.erl
+++ b/src/rebar3_appup_compile.erl
@@ -123,9 +123,10 @@ evaluate(Source, State) ->
 template(Source, Vsn) ->
     Context = [{"vsn", Vsn}],
     {ok, Template} = file:read_file(Source),
-    case catch bbmustache:render(Template, Context) of
-        B when is_binary(B) -> {ok, B};
-        Error -> {error, Error}
+    try bbmustache:render(Template, Context) of
+        B when is_binary(B) -> {ok, B}
+    catch Class:Reason:Stacktrace ->
+        {error, {Class, Reason, Stacktrace}}
     end.
 
 compile(AppupTerm, Target) ->

--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -635,15 +635,19 @@ get_supervisor_spec(Module, EbinDir) ->
     {module, Module} = rebar3_appup_utils:load_module_from_beam(Beam, Module),
     {ok, Arg} = guess_supervisor_init_arg(Module, Beam),
     rebar_api:debug("supervisor init arg: ~p", [Arg]),
-    Spec = case catch Module:init(Arg) of
+    Spec = try Module:init(Arg) of
             {ok, S} -> S;
-            _ ->
-                rebar_api:info("could not obtain supervisor ~p spec, unable to generate "
-                               "supervisor appup instructions", [Module]),
-                undefined
+            _ -> get_supervisor_spec_failed(Module)
+           catch _:_ -> get_supervisor_spec_failed(Module)
            end,
     rebar3_appup_utils:unload_module_from_beam(Beam, Module),
     Spec.
+
+get_supervisor_spec_failed(Module) ->
+    rebar_api:info("could not obtain supervisor ~p spec, unable to generate "
+                   "supervisor appup instructions", [Module]),
+    undefined.
+
 
 diff_supervisor_spec({_, Spec1}, {_, Spec2}) ->
     Workers1 = supervisor_spec_workers(Spec1, []),


### PR DESCRIPTION
Hi!

This fixes the compilation crash in OTP 29-rc2 caused by the standalone `catch` now being deprecated (replacing it with `try...catch` expressions).

Thanks!